### PR TITLE
Add Turna96 domain model and tests

### DIFF
--- a/services/turna96/Turna96.sln
+++ b/services/turna96/Turna96.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Turna96.Domain", "src/Turna96.Domain/Turna96.Domain.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Turna96.Domain.Tests", "tests/Turna96.Domain.Tests/Turna96.Domain.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageDelivered.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageDelivered.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Aggregates.MessageAggregate.Events;
+
+public sealed record MessageDelivered(MessageId MessageId, RoomId RoomId, long Sequence, DateTime DeliveredAt) : IDomainEvent;

--- a/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageRead.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageRead.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Aggregates.MessageAggregate.Events;
+
+public sealed record MessageRead(MessageId MessageId, RoomId RoomId, long Sequence, DateTime ReadAt) : IDomainEvent;

--- a/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageSent.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Events/MessageSent.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Aggregates.MessageAggregate.Events;
+
+public sealed record MessageSent(MessageId MessageId, RoomId RoomId, UserId SenderId, long Sequence, DateTime SentAt) : IDomainEvent;

--- a/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Message.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/MessageAggregate/Message.cs
@@ -1,0 +1,74 @@
+using Turna96.Domain.Aggregates.MessageAggregate.Events;
+
+namespace Turna96.Domain.Aggregates.MessageAggregate;
+
+public sealed class Message : Entity
+{
+    public MessageId Id { get; }
+    public RoomId RoomId { get; }
+    public UserId SenderId { get; }
+    public MessageBody Body { get; }
+    public string? Metadata { get; }
+    public long? Sequence { get; private set; }
+    public DateTime CreatedAt { get; }
+    public DateTime? DeletedAt { get; private set; }
+    public DateTime? DeliveredAt { get; private set; }
+    public DateTime? ReadAt { get; private set; }
+
+    private Message(MessageId id, RoomId roomId, UserId senderId, MessageBody body, string? metadata, DateTime createdAt)
+    {
+        Id = id;
+        RoomId = roomId;
+        SenderId = senderId;
+        Body = body;
+        Metadata = metadata;
+        CreatedAt = createdAt;
+    }
+
+    public static Message Create(MessageId id, RoomId roomId, UserId senderId, MessageBody body, string? metadata, IClock clock)
+        => new(id, roomId, senderId, body, metadata, clock.UtcNow);
+
+    public Result SetSequence(long sequence)
+    {
+        if (Sequence is null)
+        {
+            Sequence = sequence;
+            RaiseDomainEvent(new MessageSent(Id, RoomId, SenderId, sequence, CreatedAt));
+            return Result.Success();
+        }
+
+        if (Sequence == sequence)
+            return Result.Success();
+
+        return Result.Failure(DomainErrors.Message.SequenceMismatch);
+    }
+
+    public Result MarkDelivered(IClock clock)
+    {
+        if (DeletedAt is not null || DeliveredAt is not null)
+            return Result.Success();
+
+        DeliveredAt = clock.UtcNow;
+        RaiseDomainEvent(new MessageDelivered(Id, RoomId, Sequence!.Value, DeliveredAt.Value));
+        return Result.Success();
+    }
+
+    public Result MarkRead(IClock clock)
+    {
+        if (DeletedAt is not null || ReadAt is not null)
+            return Result.Success();
+
+        ReadAt = clock.UtcNow;
+        RaiseDomainEvent(new MessageRead(Id, RoomId, Sequence!.Value, ReadAt.Value));
+        return Result.Success();
+    }
+
+    public Result Delete(IClock clock)
+    {
+        if (DeletedAt is not null)
+            return Result.Success();
+
+        DeletedAt = clock.UtcNow;
+        return Result.Success();
+    }
+}

--- a/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Events/RoomMemberJoined.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Events/RoomMemberJoined.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Aggregates.RoomAggregate.Events;
+
+public sealed record RoomMemberJoined(RoomId RoomId, UserId UserId, DateTime JoinedAt) : IDomainEvent;

--- a/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Events/RoomMemberLeft.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Events/RoomMemberLeft.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Aggregates.RoomAggregate.Events;
+
+public sealed record RoomMemberLeft(RoomId RoomId, UserId UserId, DateTime LeftAt) : IDomainEvent;

--- a/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Room.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/Room.cs
@@ -1,0 +1,41 @@
+using Turna96.Domain.Aggregates.RoomAggregate.Events;
+
+namespace Turna96.Domain.Aggregates.RoomAggregate;
+
+public sealed class Room : Entity
+{
+    private readonly Dictionary<UserId, RoomMember> _members = new();
+
+    private Room(RoomId id, RoomType type)
+    {
+        Id = id;
+        Type = type;
+    }
+
+    public RoomId Id { get; }
+    public RoomType Type { get; }
+    public IReadOnlyCollection<RoomMember> Members => _members.Values.ToList().AsReadOnly();
+
+    public static Room Create(RoomId id, RoomType type) => new(id, type);
+
+    public Result Join(UserId userId, IClock clock)
+    {
+        if (_members.ContainsKey(userId))
+            return Result.Success();
+
+        var member = new RoomMember(userId, clock.UtcNow);
+        _members.Add(userId, member);
+        RaiseDomainEvent(new RoomMemberJoined(Id, userId, member.JoinedAt));
+        return Result.Success();
+    }
+
+    public Result Leave(UserId userId, IClock clock)
+    {
+        if (!_members.ContainsKey(userId))
+            return Result.Success();
+
+        _members.Remove(userId);
+        RaiseDomainEvent(new RoomMemberLeft(Id, userId, clock.UtcNow));
+        return Result.Success();
+    }
+}

--- a/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/RoomMember.cs
+++ b/services/turna96/src/Turna96.Domain/Aggregates/RoomAggregate/RoomMember.cs
@@ -1,0 +1,13 @@
+namespace Turna96.Domain.Aggregates.RoomAggregate;
+
+public sealed class RoomMember
+{
+    public UserId UserId { get; }
+    public DateTime JoinedAt { get; }
+
+    public RoomMember(UserId userId, DateTime joinedAt)
+    {
+        UserId = userId;
+        JoinedAt = joinedAt;
+    }
+}

--- a/services/turna96/src/Turna96.Domain/Common/Entity.cs
+++ b/services/turna96/src/Turna96.Domain/Common/Entity.cs
@@ -1,0 +1,12 @@
+namespace Turna96.Domain.Common;
+
+public abstract class Entity
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void RaiseDomainEvent(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+}

--- a/services/turna96/src/Turna96.Domain/Common/IDomainEvent.cs
+++ b/services/turna96/src/Turna96.Domain/Common/IDomainEvent.cs
@@ -1,0 +1,3 @@
+namespace Turna96.Domain.Common;
+
+public interface IDomainEvent { }

--- a/services/turna96/src/Turna96.Domain/Common/Result.cs
+++ b/services/turna96/src/Turna96.Domain/Common/Result.cs
@@ -1,0 +1,33 @@
+namespace Turna96.Domain.Common;
+
+public sealed record Error(string Code, string Description);
+
+public class Result
+{
+    public bool IsSuccess { get; }
+    public Error? Error { get; }
+
+    protected Result(bool isSuccess, Error? error)
+    {
+        IsSuccess = isSuccess;
+        Error = error;
+    }
+
+    public static Result Success() => new(true, null);
+
+    public static Result Failure(Error error) => new(false, error);
+}
+
+public sealed class Result<T> : Result
+{
+    public T? Value { get; }
+
+    private Result(bool isSuccess, T? value, Error? error) : base(isSuccess, error)
+    {
+        Value = value;
+    }
+
+    public static Result<T> Success(T value) => new(true, value, null);
+
+    public static new Result<T> Failure(Error error) => new(false, default, error);
+}

--- a/services/turna96/src/Turna96.Domain/Common/ValueObject.cs
+++ b/services/turna96/src/Turna96.Domain/Common/ValueObject.cs
@@ -1,0 +1,18 @@
+namespace Turna96.Domain.Common;
+
+public abstract record ValueObject
+{
+    protected abstract IEnumerable<object?> GetEqualityComponents();
+
+    public virtual bool Equals(ValueObject? other)
+    {
+        if (other is null || other.GetType() != GetType()) return false;
+        return GetEqualityComponents().SequenceEqual(other.GetEqualityComponents());
+    }
+
+    public override int GetHashCode()
+    {
+        return GetEqualityComponents()
+            .Aggregate(0, (current, obj) => HashCode.Combine(current, obj));
+    }
+}

--- a/services/turna96/src/Turna96.Domain/Enums/RoomType.cs
+++ b/services/turna96/src/Turna96.Domain/Enums/RoomType.cs
@@ -1,0 +1,7 @@
+namespace Turna96.Domain.Enums;
+
+public enum RoomType
+{
+    Direct = 1,
+    Group = 2
+}

--- a/services/turna96/src/Turna96.Domain/Errors/DomainErrors.Message.cs
+++ b/services/turna96/src/Turna96.Domain/Errors/DomainErrors.Message.cs
@@ -1,0 +1,11 @@
+namespace Turna96.Domain.Errors;
+
+public static partial class DomainErrors
+{
+    public static class Message
+    {
+        public static readonly Error Empty = new("Message.Empty", "Message body cannot be empty.");
+        public static readonly Error TooLong = new("Message.TooLong", "Message body must be 4096 bytes or less.");
+        public static readonly Error SequenceMismatch = new("Message.SequenceMismatch", "Message sequence mismatch.");
+    }
+}

--- a/services/turna96/src/Turna96.Domain/Errors/DomainErrors.Room.cs
+++ b/services/turna96/src/Turna96.Domain/Errors/DomainErrors.Room.cs
@@ -1,0 +1,10 @@
+namespace Turna96.Domain.Errors;
+
+public static partial class DomainErrors
+{
+    public static class Room
+    {
+        public static readonly Error MemberAlreadyExists = new("Room.MemberAlreadyExists", "User already joined the room.");
+        public static readonly Error MemberNotFound = new("Room.MemberNotFound", "User is not a member of the room.");
+    }
+}

--- a/services/turna96/src/Turna96.Domain/GlobalUsings.cs
+++ b/services/turna96/src/Turna96.Domain/GlobalUsings.cs
@@ -1,0 +1,6 @@
+namespace Turna96.Domain;
+
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using Turna96.Domain.Common;

--- a/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IMessageRepository.cs
+++ b/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IMessageRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turna96.Domain.Interfaces.Repositories;
+
+public interface IMessageRepository
+{
+    Task AddAsync(Message message, CancellationToken cancellationToken = default);
+    Task<Message?> GetByIdAsync(MessageId id, CancellationToken cancellationToken = default);
+}

--- a/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IRoomRepository.cs
+++ b/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IRoomRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turna96.Domain.Interfaces.Repositories;
+
+public interface IRoomRepository
+{
+    Task AddAsync(Room room, CancellationToken cancellationToken = default);
+    Task<Room?> GetByIdAsync(RoomId id, CancellationToken cancellationToken = default);
+}

--- a/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IUnitOfWork.cs
+++ b/services/turna96/src/Turna96.Domain/Interfaces/Repositories/IUnitOfWork.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turna96.Domain.Interfaces.Repositories;
+
+public interface IUnitOfWork
+{
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/turna96/src/Turna96.Domain/Services/IClock.cs
+++ b/services/turna96/src/Turna96.Domain/Services/IClock.cs
@@ -1,0 +1,6 @@
+namespace Turna96.Domain.Services;
+
+public interface IClock
+{
+    DateTime UtcNow { get; }
+}

--- a/services/turna96/src/Turna96.Domain/Services/IMessageSequencer.cs
+++ b/services/turna96/src/Turna96.Domain/Services/IMessageSequencer.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turna96.Domain.Services;
+
+public interface IMessageSequencer
+{
+    Task<long> NextAsync(RoomId roomId, CancellationToken cancellationToken = default);
+}

--- a/services/turna96/src/Turna96.Domain/Turna96.Domain.csproj
+++ b/services/turna96/src/Turna96.Domain/Turna96.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/services/turna96/src/Turna96.Domain/ValueObjects/MessageBody.cs
+++ b/services/turna96/src/Turna96.Domain/ValueObjects/MessageBody.cs
@@ -1,0 +1,28 @@
+using System.Text;
+
+namespace Turna96.Domain.ValueObjects;
+
+public sealed class MessageBody : ValueObject
+{
+    public string Value { get; }
+
+    private MessageBody(string value) => Value = value;
+
+    public static Result<MessageBody> Create(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return Result<MessageBody>.Failure(DomainErrors.Message.Empty);
+
+        if (Encoding.UTF8.GetByteCount(value) > 4096)
+            return Result<MessageBody>.Failure(DomainErrors.Message.TooLong);
+
+        return Result<MessageBody>.Success(new MessageBody(value));
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+
+    public override string ToString() => Value;
+}

--- a/services/turna96/src/Turna96.Domain/ValueObjects/MessageId.cs
+++ b/services/turna96/src/Turna96.Domain/ValueObjects/MessageId.cs
@@ -1,0 +1,11 @@
+namespace Turna96.Domain.ValueObjects;
+
+public sealed record MessageId(Guid Value) : ValueObject
+{
+    public static MessageId New() => new(Guid.NewGuid());
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+}

--- a/services/turna96/src/Turna96.Domain/ValueObjects/RoomId.cs
+++ b/services/turna96/src/Turna96.Domain/ValueObjects/RoomId.cs
@@ -1,0 +1,11 @@
+namespace Turna96.Domain.ValueObjects;
+
+public sealed record RoomId(Guid Value) : ValueObject
+{
+    public static RoomId New() => new(Guid.NewGuid());
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+}

--- a/services/turna96/src/Turna96.Domain/ValueObjects/UserId.cs
+++ b/services/turna96/src/Turna96.Domain/ValueObjects/UserId.cs
@@ -1,0 +1,11 @@
+namespace Turna96.Domain.ValueObjects;
+
+public sealed record UserId(Guid Value) : ValueObject
+{
+    public static UserId New() => new(Guid.NewGuid());
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageCreationTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageCreationTests.cs
@@ -1,0 +1,20 @@
+using Turna96.Domain.Aggregates.MessageAggregate;
+using Turna96.Domain.Tests.Fakes;
+using Xunit;
+
+namespace Turna96.Domain.Tests.Aggregates.MessageAggregate;
+
+public class MessageCreationTests
+{
+    [Fact]
+    public void Create_Should_Set_CreatedAt_And_NoSequence()
+    {
+        var fixedTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var clock = new FakeClock(fixedTime);
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+
+        Assert.Equal(fixedTime, message.CreatedAt);
+        Assert.Null(message.Sequence);
+        Assert.Empty(message.DomainEvents);
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageDeliveryReadTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageDeliveryReadTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using Turna96.Domain.Aggregates.MessageAggregate;
+using Turna96.Domain.Aggregates.MessageAggregate.Events;
+using Turna96.Domain.Tests.Fakes;
+using Xunit;
+
+namespace Turna96.Domain.Tests.Aggregates.MessageAggregate;
+
+public class MessageDeliveryReadTests
+{
+    [Fact]
+    public void MarkDelivered_Should_Be_Idempotent()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+        message.SetSequence(1);
+
+        message.MarkDelivered(clock);
+        message.MarkDelivered(clock);
+
+        Assert.Equal(1, message.DomainEvents.OfType<MessageDelivered>().Count());
+    }
+
+    [Fact]
+    public void MarkRead_Should_Be_Idempotent()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+        message.SetSequence(1);
+
+        message.MarkRead(clock);
+        message.MarkRead(clock);
+
+        Assert.Equal(1, message.DomainEvents.OfType<MessageRead>().Count());
+    }
+
+    [Fact]
+    public void Deleted_Message_Should_Not_Raise_Delivery_Or_Read_Events()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+        message.SetSequence(1);
+        message.Delete(clock);
+
+        message.MarkDelivered(clock);
+        message.MarkRead(clock);
+
+        Assert.Empty(message.DomainEvents.OfType<MessageDelivered>());
+        Assert.Empty(message.DomainEvents.OfType<MessageRead>());
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageSequenceTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Aggregates/MessageAggregate/MessageSequenceTests.cs
@@ -1,0 +1,49 @@
+using Turna96.Domain.Aggregates.MessageAggregate;
+using Turna96.Domain.Errors;
+using Turna96.Domain.Tests.Fakes;
+using Xunit;
+
+namespace Turna96.Domain.Tests.Aggregates.MessageAggregate;
+
+public class MessageSequenceTests
+{
+    [Fact]
+    public void SetSequence_FirstTime_Should_RaiseEvent()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+
+        var result = message.SetSequence(1);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, message.Sequence);
+        Assert.Single(message.DomainEvents);
+    }
+
+    [Fact]
+    public void SetSequence_SameValue_Should_Be_Idempotent()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+        message.SetSequence(1);
+
+        var result = message.SetSequence(1);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, message.Sequence);
+        Assert.Single(message.DomainEvents);
+    }
+
+    [Fact]
+    public void SetSequence_DifferentValue_Should_Fail()
+    {
+        var clock = new FakeClock();
+        var message = Message.Create(TestData.MessageId, TestData.RoomId, TestData.UserA, TestData.ValidBody, null, clock);
+        message.SetSequence(1);
+
+        var result = message.SetSequence(2);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DomainErrors.Message.SequenceMismatch, result.Error);
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Aggregates/RoomAggregate/RoomMembershipTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Aggregates/RoomAggregate/RoomMembershipTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Turna96.Domain.Aggregates.RoomAggregate;
+using Turna96.Domain.Aggregates.RoomAggregate.Events;
+using Turna96.Domain.Enums;
+using Turna96.Domain.Tests.Fakes;
+using Xunit;
+
+namespace Turna96.Domain.Tests.Aggregates.RoomAggregate;
+
+public class RoomMembershipTests
+{
+    [Fact]
+    public void Join_Should_Be_Idempotent()
+    {
+        var clock = new FakeClock();
+        var room = Room.Create(TestData.RoomId, RoomType.Group);
+
+        var first = room.Join(TestData.UserA, clock);
+        var second = room.Join(TestData.UserA, clock);
+
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.Single(room.Members);
+        Assert.Equal(1, room.DomainEvents.OfType<RoomMemberJoined>().Count());
+    }
+
+    [Fact]
+    public void Leave_Should_Be_Idempotent()
+    {
+        var clock = new FakeClock();
+        var room = Room.Create(TestData.RoomId, RoomType.Group);
+
+        room.Join(TestData.UserA, clock);
+        var first = room.Leave(TestData.UserA, clock);
+        var second = room.Leave(TestData.UserA, clock);
+
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.Empty(room.Members);
+        Assert.Equal(2, room.DomainEvents.Count);
+        Assert.Equal(1, room.DomainEvents.OfType<RoomMemberLeft>().Count());
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Fakes/FakeClock.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Fakes/FakeClock.cs
@@ -1,0 +1,15 @@
+using Turna96.Domain.Services;
+
+namespace Turna96.Domain.Tests.Fakes;
+
+public sealed class FakeClock : IClock
+{
+    public DateTime UtcNow { get; set; }
+
+    public FakeClock(DateTime? utcNow = null)
+    {
+        UtcNow = utcNow ?? DateTime.UtcNow;
+    }
+
+    public void Advance(TimeSpan span) => UtcNow = UtcNow.Add(span);
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Fakes/TestData.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/Fakes/TestData.cs
@@ -1,0 +1,12 @@
+using Turna96.Domain.ValueObjects;
+
+namespace Turna96.Domain.Tests.Fakes;
+
+public static class TestData
+{
+    public static readonly UserId UserA = UserId.New();
+    public static readonly UserId UserB = UserId.New();
+    public static readonly RoomId RoomId = ValueObjects.RoomId.New();
+    public static readonly MessageId MessageId = ValueObjects.MessageId.New();
+    public static MessageBody ValidBody => MessageBody.Create("hello world").Value!;
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/Turna96.Domain.Tests.csproj
+++ b/services/turna96/tests/Turna96.Domain.Tests/Turna96.Domain.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Turna96.Domain/Turna96.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+</Project>

--- a/services/turna96/tests/Turna96.Domain.Tests/ValueEquality/ValueObjectEqualityTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/ValueEquality/ValueObjectEqualityTests.cs
@@ -1,0 +1,17 @@
+using Turna96.Domain.ValueObjects;
+using Xunit;
+
+namespace Turna96.Domain.Tests.ValueEquality;
+
+public class ValueObjectEqualityTests
+{
+    [Fact]
+    public void UserId_WithSameGuid_ShouldBeEqual()
+    {
+        var id = Guid.NewGuid();
+        var first = new UserId(id);
+        var second = new UserId(id);
+
+        Assert.Equal(first, second);
+    }
+}

--- a/services/turna96/tests/Turna96.Domain.Tests/ValueObjects/MessageBodyTests.cs
+++ b/services/turna96/tests/Turna96.Domain.Tests/ValueObjects/MessageBodyTests.cs
@@ -1,0 +1,24 @@
+using Turna96.Domain.ValueObjects;
+using Turna96.Domain.Errors;
+using Xunit;
+
+namespace Turna96.Domain.Tests.ValueObjects;
+
+public class MessageBodyTests
+{
+    [Fact]
+    public void Create_Should_ReturnSuccess_WhenWithinLimit()
+    {
+        var result = MessageBody.Create(new string('a', 10));
+        Assert.True(result.IsSuccess);
+        Assert.Equal(10, result.Value!.Value.Length);
+    }
+
+    [Fact]
+    public void Create_Should_Fail_WhenExceedsLimit()
+    {
+        var result = MessageBody.Create(new string('a', 4097));
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DomainErrors.Message.TooLong, result.Error);
+    }
+}


### PR DESCRIPTION
## Summary
- implement domain aggregates, value objects, services, errors, and events for Turna96
- add repository interfaces and supporting infrastructure
- provide comprehensive unit tests for message and room behavior

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b73f5a264c83329b070eef77ca5eba