### PR TITLE
Add interview platform identity infrastructure

### DIFF
--- a/docs/identity/phase-1-report.md
+++ b/docs/identity/phase-1-report.md
@@ -1,0 +1,32 @@
+# Faz 1 – Kimlik ve Oturum Altyapısı
+
+Bu fazda Turna96 Interview Studio için modern bir kimlik doğrulama katmanı inşa edildi. ASP.NET Core Identity kullanılarak adayların mülakat simülasyonlarına güvenle erişebilmesi sağlandı.
+
+## Öne Çıkanlar
+
+- **ASP.NET Core Identity + SQL Server:** EF Core tabanlı ApplicationDbContext ile güçlü bir kullanıcı yönetimi temeli kuruldu. Parola politikaları, kilitlenme eşikleri ve iki faktörlü doğrulama senaryoları yapılandırıldı.
+- **Kişiselleştirilmiş aday profili:** Identity kullanıcısı genişletilerek adayların `FullName`, `CurrentRole` ve `TargetLevel` bilgileri tutulur hale getirildi. Profil yönetim ekranı bu alanları güncelleme desteği sunar.
+- **Tema uyumlu arayüzler:** Giriş, kayıt, parola sıfırlama ve hesap yönetimi sayfaları mülakat eğitim platformuna uygun koyu temalı, motivasyon odaklı bir tasarımla hazırlandı. Bootstrap 5 ve özel CSS ile card tabanlı modern bir UI oluşturuldu.
+- **Debug e-posta gönderimi:** Geliştirme aşamasında e-posta doğrulama ve parola sıfırlama akışlarını izlemek için `DebugEmailSender` servisi tanımlandı. Gerçek SMTP entegrasyonu için genişletilebilir yapı hazır.
+- **Hazır 2FA adımları:** Authenticator kodu ve kurtarma kodu ile giriş ekranları aktifleştirildi; ilerleyen fazlarda MFA politikaları kolaylıkla devreye alınabilir.
+
+## Kurulum ve Çalıştırma
+
+1. SQL Server örneğinizi ayarlayın (Docker veya yerel).
+2. `appsettings.json` içindeki `DefaultConnection` değerini güncel veritabanınıza göre değiştirin.
+3. İlk şema için EF Core migration oluşturun:
+   ```bash
+   dotnet ef migrations add InitialIdentity --project services/turna96/InterviewPrep.Web
+   dotnet ef database update --project services/turna96/InterviewPrep.Web
+   ```
+4. Uygulamayı çalıştırın:
+   ```bash
+   dotnet run --project services/turna96/InterviewPrep.Web
+   ```
+
+## Sonraki Adımlar
+
+- OpenAI Assistants API ile kişiselleştirilmiş soru üretimi.
+- Gelişmiş ilerleme panosu ve oyunlaştırma bileşenlerinin devreye alınması.
+- Gerçek e-posta/SMS sağlayıcısı ile MFA entegrasyonu.
+- Admin paneli ve soru yönetimi için ayrı modüllerin geliştirilmesi.

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
@@ -1,0 +1,20 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.ConfirmEmailModel
+@{
+    ViewData["Title"] = "E-posta Doğrulama";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <div class="feature-icon mx-auto mb-3">
+                    <i class="bi bi-patch-check fs-4"></i>
+                </div>
+                <h2 class="fw-bold text-white">Doğrulama sonucu</h2>
+                <p class="text-secondary mt-3">@Model.StatusMessage</p>
+                <a class="btn btn-primary mt-3" asp-page="./Login">Giriş ekranına dön</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,0 +1,43 @@
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class ConfirmEmailModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public ConfirmEmailModel(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    [TempData]
+    public string StatusMessage { get; set; } = string.Empty;
+
+    public async Task<IActionResult> OnGetAsync(string? userId, string? code)
+    {
+        if (userId == null || code == null)
+        {
+            return RedirectToPage("/Index");
+        }
+
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user == null)
+        {
+            return NotFound($"Bu ID'ye sahip kullanıcı bulunamadı: {userId}");
+        }
+
+        var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+        var result = await _userManager.ConfirmEmailAsync(user, decodedCode);
+        StatusMessage = result.Succeeded
+            ? "E-posta adresin doğrulandı. Artık simülasyonlara giriş yapabilirsin."
+            : "E-posta doğrulaması sırasında bir hata meydana geldi.";
+
+        return Page();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml
@@ -1,0 +1,34 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.ForgotPasswordModel
+@{
+    ViewData["Title"] = "Parolamı Unuttum";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xl-5">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-3">Parola sıfırlama bağlantısı iste</h2>
+                <p class="text-secondary text-center mb-4">
+                    E-posta adresini gir, sana güvenli bir sıfırlama bağlantısı gönderelim. Hesabına yetkisiz erişimi engellemek için bağlantı kısa süreli geçerlidir.
+                </p>
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <div class="mb-3">
+                        <label asp-for="Input.Email" class="form-label"></label>
+                        <input asp-for="Input.Email" class="form-control form-control-lg" autocomplete="username" />
+                        <span asp-validation-for="Input.Email" class="text-danger"></span>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100">Bağlantı gönder</button>
+                </form>
+            </div>
+        </div>
+        <div class="text-center mt-3">
+            <a class="link-light-muted" asp-page="./Login">Giriş ekranına dön</a>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using InterviewPrep.Web.Models;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class ForgotPasswordModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailSender _emailSender;
+
+    public ForgotPasswordModel(UserManager<ApplicationUser> userManager, IEmailSender emailSender)
+    {
+        _userManager = userManager;
+        _emailSender = emailSender;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        [Required(ErrorMessage = "E-posta adresinizi giriniz.")]
+        [EmailAddress]
+        [Display(Name = "E-posta")]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (ModelState.IsValid)
+        {
+            var user = await _userManager.FindByEmailAsync(Input.Email);
+            if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
+            {
+                return RedirectToPage("./ForgotPasswordConfirmation");
+            }
+
+            var code = await _userManager.GeneratePasswordResetTokenAsync(user);
+            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+            var callbackUrl = Url.Page(
+                "/Account/ResetPassword",
+                pageHandler: null,
+                values: new { area = "Identity", code },
+                protocol: Request.Scheme);
+
+            await _emailSender.SendEmailAsync(
+                Input.Email,
+                "Turna Interview Studio - Parola Sıfırlama",
+                $"<p>Merhaba {HtmlEncoder.Default.Encode(user.FullName ?? user.Email ?? string.Empty)},</p>" +
+                "<p>Parolanı sıfırlamak için aşağıdaki bağlantıya tıkla:</p>" +
+                $"<p><a href='{HtmlEncoder.Default.Encode(callbackUrl!)}'>Parolamı sıfırla</a></p>");
+
+            return RedirectToPage("./ForgotPasswordConfirmation");
+        }
+
+        return Page();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ForgotPasswordConfirmation.cshtml
@@ -1,0 +1,23 @@
+@page
+@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+@{
+    ViewData["Title"] = "Bağlantı Gönderildi";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <div class="feature-icon mx-auto mb-3">
+                    <i class="bi bi-envelope-check fs-4"></i>
+                </div>
+                <h2 class="fw-bold text-white">E-postanı kontrol et</h2>
+                <p class="text-secondary mt-3">
+                    Parola sıfırlama bağlantısını e-posta adresine gönderdik. Gelen kutunu ve spam klasörünü kontrol et.
+                    Bağlantı güvenlik nedeniyle yalnızca kısa bir süre geçerli.
+                </p>
+                <a class="btn btn-outline-light mt-3" asp-page="./Login">Giriş ekranına dön</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Lockout.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Lockout.cshtml
@@ -1,0 +1,21 @@
+@page
+@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+@{
+    ViewData["Title"] = "Hesap Kilitlendi";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <div class="feature-icon mx-auto mb-3">
+                    <i class="bi bi-lock fs-4"></i>
+                </div>
+                <h2 class="fw-bold text-white">Hesabın geçici olarak kilitlendi</h2>
+                <p class="text-secondary">
+                    Birden fazla başarısız giriş denemesi tespit edildi. Güvenliğin için oturuma ara verdik. Bir süre sonra tekrar dene veya destekle iletişime geç.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -1,0 +1,49 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.LoginModel
+@{
+    ViewData["Title"] = "Giriş Yap";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xl-5">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-4">Tekrar hoş geldin!</h2>
+                <p class="text-secondary text-center mb-4">
+                    Bugünkü mülakat görevin seni bekliyor. Streak'ini bozmadan ilerlemek için oturum aç.
+                </p>
+                <form id="account" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <div class="mb-3">
+                        <label asp-for="Input.Email" class="form-label"></label>
+                        <input asp-for="Input.Email" class="form-control form-control-lg" autocomplete="username" />
+                        <span asp-validation-for="Input.Email" class="text-danger"></span>
+                    </div>
+                    <div class="mb-3">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <label asp-for="Input.Password" class="form-label"></label>
+                            <a class="link-light-muted small" asp-page="./ForgotPassword">Parolamı unuttum</a>
+                        </div>
+                        <input asp-for="Input.Password" class="form-control form-control-lg" autocomplete="current-password" />
+                        <span asp-validation-for="Input.Password" class="text-danger"></span>
+                    </div>
+                    <div class="mb-4 form-check">
+                        <input class="form-check-input" asp-for="Input.RememberMe" />
+                        <label class="form-check-label" asp-for="Input.RememberMe"></label>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100">Giriş yap</button>
+                </form>
+                <div class="mt-4 text-center text-secondary">
+                    Hesabın yok mu? <a class="link-light" asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Hemen kayıt ol</a>
+                </div>
+            </div>
+        </div>
+        <p class="text-center text-secondary mt-3 small">
+            Çok faktörlü doğrulama etkinse bir sonraki adımda kod isteyeceğiz.
+        </p>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class LoginModel : PageModel
+{
+    private readonly SignInManager<Models.ApplicationUser> _signInManager;
+
+    public LoginModel(SignInManager<Models.ApplicationUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public IList<AuthenticationScheme> ExternalLogins { get; set; } = new List<AuthenticationScheme>();
+
+    public string? ReturnUrl { get; set; }
+
+    [TempData]
+    public string? ErrorMessage { get; set; }
+
+    public class InputModel
+    {
+        [Required(ErrorMessage = "E-posta adresinizi giriniz.")]
+        [EmailAddress(ErrorMessage = "Geçerli bir e-posta adresi giriniz.")]
+        [Display(Name = "E-posta")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Parolanızı giriniz.")]
+        [DataType(DataType.Password)]
+        [Display(Name = "Parola")]
+        public string Password { get; set; } = string.Empty;
+
+        [Display(Name = "Beni hatırla?")]
+        public bool RememberMe { get; set; }
+    }
+
+    public async Task OnGetAsync(string? returnUrl = null)
+    {
+        if (!string.IsNullOrEmpty(ErrorMessage))
+        {
+            ModelState.AddModelError(string.Empty, ErrorMessage);
+        }
+
+        returnUrl ??= Url.Content("~/");
+
+        await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+        ReturnUrl = returnUrl;
+    }
+
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+    {
+        returnUrl ??= Url.Content("~/");
+
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+        if (ModelState.IsValid)
+        {
+            var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: true);
+
+            if (result.Succeeded)
+            {
+                return LocalRedirect(returnUrl);
+            }
+            if (result.RequiresTwoFactor)
+            {
+                return RedirectToPage("./LoginWith2fa", new { ReturnUrl = returnUrl, RememberMe = Input.RememberMe });
+            }
+            if (result.IsLockedOut)
+            {
+                return RedirectToPage("./Lockout");
+            }
+            else
+            {
+                ModelState.AddModelError(string.Empty, "Geçersiz giriş denemesi.");
+                return Page();
+            }
+        }
+
+        return Page();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWith2fa.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWith2fa.cshtml
@@ -1,0 +1,38 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.LoginWith2faModel
+@{
+    ViewData["Title"] = "İki Faktörlü Giriş";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xl-5">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-3">Güvenlik doğrulaması</h2>
+                <p class="text-secondary text-center mb-4">
+                    Kimliğini doğrulamak için authenticator uygulamandaki 6 haneli kodu gir.
+                </p>
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <div class="mb-3">
+                        <label asp-for="Input.TwoFactorCode" class="form-label"></label>
+                        <input asp-for="Input.TwoFactorCode" class="form-control form-control-lg text-center" autocomplete="one-time-code" />
+                        <span asp-validation-for="Input.TwoFactorCode" class="text-danger"></span>
+                    </div>
+                    <div class="form-check mb-4">
+                        <input class="form-check-input" asp-for="Input.RememberMachine" />
+                        <label class="form-check-label" asp-for="Input.RememberMachine"></label>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100">Doğrula ve devam et</button>
+                </form>
+                <div class="text-center mt-3">
+                    <a class="link-light-muted" asp-page="./LoginWithRecoveryCode" asp-route-returnUrl="@Url.Content("~/")">Kodumu kaybettim</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using InterviewPrep.Web.Models;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class LoginWith2faModel : PageModel
+{
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public LoginWith2faModel(SignInManager<ApplicationUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public bool RememberMe { get; set; }
+
+    public class InputModel
+    {
+        [Required]
+        [StringLength(7, ErrorMessage = "Kod en az {2}, en fazla {1} karakter olmalıdır.", MinimumLength = 6)]
+        [DataType(DataType.Text)]
+        [Display(Name = "Doğrulama kodu")]
+        public string TwoFactorCode { get; set; } = string.Empty;
+
+        [Display(Name = "Bu cihazı hatırla")]
+        public bool RememberMachine { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(bool rememberMe, string? returnUrl = null)
+    {
+        var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();
+        if (user == null)
+        {
+            throw new InvalidOperationException("İki faktörlü doğrulama kullanıcısı bulunamadı.");
+        }
+
+        RememberMe = rememberMe;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(bool rememberMe, string? returnUrl = null)
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        returnUrl ??= Url.Content("~/");
+
+        var result = await _signInManager.TwoFactorAuthenticatorSignInAsync(Input.TwoFactorCode.Replace(" ", string.Empty), rememberMe, Input.RememberMachine);
+
+        if (result.Succeeded)
+        {
+            return LocalRedirect(returnUrl);
+        }
+        if (result.IsLockedOut)
+        {
+            return RedirectToPage("./Lockout");
+        }
+        else
+        {
+            ModelState.AddModelError(string.Empty, "Geçersiz doğrulama kodu.");
+            return Page();
+        }
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml
@@ -1,0 +1,34 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.LoginWithRecoveryCodeModel
+@{
+    ViewData["Title"] = "Kurtarma Kodu ile Giriş";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xl-5">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-3">Kurtarma kodunu gir</h2>
+                <p class="text-secondary text-center mb-4">
+                    Authenticator erişimin yoksa kayıt sırasında verilen kurtarma kodlarından birini kullanabilirsin.
+                </p>
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <div class="mb-3">
+                        <label asp-for="Input.RecoveryCode" class="form-label"></label>
+                        <input asp-for="Input.RecoveryCode" class="form-control form-control-lg text-center" autocomplete="one-time-code" />
+                        <span asp-validation-for="Input.RecoveryCode" class="text-danger"></span>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100">Devam et</button>
+                </form>
+                <div class="text-center mt-3">
+                    <a class="link-light-muted" asp-page="./Login">Authenticator'a geri dön</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using InterviewPrep.Web.Models;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class LoginWithRecoveryCodeModel : PageModel
+{
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public LoginWithRecoveryCodeModel(SignInManager<ApplicationUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public string? ReturnUrl { get; set; }
+
+    public class InputModel
+    {
+        [Required]
+        [DataType(DataType.Text)]
+        [Display(Name = "Kurtarma kodu")]
+        public string RecoveryCode { get; set; } = string.Empty;
+    }
+
+    public async Task<IActionResult> OnGetAsync(string? returnUrl = null)
+    {
+        var user = await _signInManager.GetTwoFactorAuthenticationUserAsync();
+        if (user == null)
+        {
+            throw new InvalidOperationException("İki faktörlü doğrulama kullanıcısı bulunamadı.");
+        }
+
+        ReturnUrl = returnUrl;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        returnUrl ??= Url.Content("~/");
+
+        var result = await _signInManager.TwoFactorRecoveryCodeSignInAsync(Input.RecoveryCode.Replace(" ", string.Empty));
+
+        if (result.Succeeded)
+        {
+            return LocalRedirect(returnUrl);
+        }
+        if (result.IsLockedOut)
+        {
+            return RedirectToPage("./Lockout");
+        }
+        else
+        {
+            ModelState.AddModelError(string.Empty, "Geçersiz kurtarma kodu.");
+            return Page();
+        }
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Logout.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Logout.cshtml
@@ -1,0 +1,19 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.LogoutModel
+@{
+    ViewData["Title"] = "Güvenli Çıkış";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <h2 class="fw-bold text-white">Oturumun kapatıldı</h2>
+                <p class="text-secondary">
+                    Mülakat simülasyonlarını sürdürmek için hazır olduğunda tekrar giriş yapabilirsin.
+                </p>
+                <a class="btn btn-primary" asp-page="./Login">Tekrar giriş yap</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using InterviewPrep.Web.Models;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class LogoutModel : PageModel
+{
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public LogoutModel(SignInManager<ApplicationUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    public async Task<IActionResult> OnPost(string? returnUrl = null)
+    {
+        await _signInManager.SignOutAsync();
+        if (returnUrl != null)
+        {
+            return LocalRedirect(returnUrl);
+        }
+
+        return RedirectToPage();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -1,0 +1,42 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.Manage.ChangePasswordModel
+@{
+    ViewData["Title"] = "Parola Değiştir";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white mb-4">Parolanı güncelle</h2>
+                <partial name="_ManageNav" />
+                <partial name="_StatusMessage" for="StatusMessage" />
+                <form method="post" class="row g-3">
+                    <div class="col-12">
+                        <label asp-for="Input.OldPassword" class="form-label"></label>
+                        <input asp-for="Input.OldPassword" class="form-control form-control-lg" autocomplete="current-password" />
+                        <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.NewPassword" class="form-label"></label>
+                        <input asp-for="Input.NewPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+                        <input asp-for="Input.ConfirmPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary btn-lg">Parolayı güncelle</button>
+                        <a asp-page="./Index" class="btn btn-outline-light btn-lg ms-2">İptal</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account.Manage;
+
+public class ChangePasswordModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public ChangePasswordModel(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    [TempData]
+    public string StatusMessage { get; set; } = string.Empty;
+
+    public class InputModel
+    {
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Mevcut parola")]
+        public string OldPassword { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, ErrorMessage = "{0} en az {2} en fazla {1} karakter olmalıdır.", MinimumLength = 8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Yeni parola")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Yeni parolayı doğrula")]
+        [Compare("NewPassword", ErrorMessage = "Parolalar eşleşmiyor.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        var hasPassword = await _userManager.HasPasswordAsync(user);
+        if (!hasPassword)
+        {
+            return RedirectToPage("./SetPassword");
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        var changePasswordResult = await _userManager.ChangePasswordAsync(user, Input.OldPassword, Input.NewPassword);
+        if (!changePasswordResult.Succeeded)
+        {
+            foreach (var error in changePasswordResult.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+            return Page();
+        }
+
+        await _signInManager.RefreshSignInAsync(user);
+        StatusMessage = "Parolanız güncellendi.";
+        return RedirectToPage();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -1,0 +1,52 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.Manage.IndexModel
+@{
+    ViewData["Title"] = "Profilim";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white mb-4">Profil Bilgileri</h2>
+                <partial name="_ManageNav" />
+                <partial name="_StatusMessage" for="StatusMessage" />
+                <form method="post" class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.FullName" class="form-label"></label>
+                        <input asp-for="Input.FullName" class="form-control form-control-lg" />
+                        <span asp-validation-for="Input.FullName" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.PhoneNumber" class="form-label"></label>
+                        <input asp-for="Input.PhoneNumber" class="form-control form-control-lg" />
+                        <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.CurrentRole" class="form-label"></label>
+                        <input asp-for="Input.CurrentRole" class="form-control form-control-lg" />
+                        <span asp-validation-for="Input.CurrentRole" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.TargetLevel" class="form-label"></label>
+                        <select asp-for="Input.TargetLevel" class="form-select form-select-lg">
+                            <option value="Junior">Junior</option>
+                            <option value="Middle">Middle</option>
+                            <option value="Senior">Senior</option>
+                            <option value="Lead">Lead</option>
+                        </select>
+                        <span asp-validation-for="Input.TargetLevel" class="text-danger"></span>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary btn-lg">Değişiklikleri kaydet</button>
+                        <a asp-page="./ChangePassword" class="btn btn-outline-light btn-lg ms-2">Parolayı değiştir</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel.DataAnnotations;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account.Manage;
+
+public class IndexModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public IndexModel(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [TempData]
+    public string StatusMessage { get; set; } = string.Empty;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        [Display(Name = "Ad Soyad")]
+        [Required]
+        public string FullName { get; set; } = string.Empty;
+
+        [Phone]
+        [Display(Name = "Telefon")]
+        public string? PhoneNumber { get; set; }
+
+        [Display(Name = "Şu anki rol")]
+        public string? CurrentRole { get; set; }
+
+        [Display(Name = "Hedef seviye")]
+        public string? TargetLevel { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        Input = new InputModel
+        {
+            FullName = user.FullName ?? string.Empty,
+            PhoneNumber = await _userManager.GetPhoneNumberAsync(user),
+            CurrentRole = user.CurrentRole,
+            TargetLevel = user.TargetLevel
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        user.FullName = Input.FullName;
+        user.CurrentRole = Input.CurrentRole;
+        user.TargetLevel = Input.TargetLevel;
+
+        var phoneNumber = await _userManager.GetPhoneNumberAsync(user);
+        if (Input.PhoneNumber != phoneNumber)
+        {
+            var setPhoneResult = await _userManager.SetPhoneNumberAsync(user, Input.PhoneNumber);
+            if (!setPhoneResult.Succeeded)
+            {
+                StatusMessage = "Telefon numarası güncellenemedi.";
+                return RedirectToPage();
+            }
+        }
+
+        await _userManager.UpdateAsync(user);
+        await _signInManager.RefreshSignInAsync(user);
+        StatusMessage = "Profil bilgileriniz güncellendi.";
+        return RedirectToPage();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml
@@ -1,0 +1,37 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.Manage.SetPasswordModel
+@{
+    ViewData["Title"] = "Parola Oluştur";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white mb-4">Hesabın için parola belirle</h2>
+                <partial name="_ManageNav" />
+                <partial name="_StatusMessage" for="StatusMessage" />
+                <form method="post" class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.NewPassword" class="form-label"></label>
+                        <input asp-for="Input.NewPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+                        <input asp-for="Input.ConfirmPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary btn-lg">Parola oluştur</button>
+                        <a asp-page="./Index" class="btn btn-outline-light btn-lg ms-2">İptal</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel.DataAnnotations;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account.Manage;
+
+public class SetPasswordModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public SetPasswordModel(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    [TempData]
+    public string StatusMessage { get; set; } = string.Empty;
+
+    public class InputModel
+    {
+        [Required]
+        [StringLength(100, ErrorMessage = "{0} en az {2} en fazla {1} karakter olmalıdır.", MinimumLength = 8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Yeni parola")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Parolayı doğrula")]
+        [Compare("NewPassword", ErrorMessage = "Parolalar eşleşmiyor.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        var hasPassword = await _userManager.HasPasswordAsync(user);
+        if (hasPassword)
+        {
+            return RedirectToPage("./ChangePassword");
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound("Kullanıcı bulunamadı.");
+        }
+
+        var addPasswordResult = await _userManager.AddPasswordAsync(user, Input.NewPassword);
+        if (!addPasswordResult.Succeeded)
+        {
+            foreach (var error in addPasswordResult.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+            return Page();
+        }
+
+        await _signInManager.RefreshSignInAsync(user);
+        StatusMessage = "Parolanız oluşturuldu.";
+        return RedirectToPage("./Index");
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -1,0 +1,9 @@
+@using Microsoft.AspNetCore.Mvc.Rendering
+@{
+    var activePage = ViewContext.ActionDescriptor.DisplayName;
+}
+<nav class="nav nav-pills flex-column flex-md-row gap-2 mb-4">
+    <a class="nav-link @(ViewContext.RouteData.Values["page"]?.ToString()?.EndsWith("Index") == true ? "active" : string.Empty)" asp-page="./Index">Profil</a>
+    <a class="nav-link @(ViewContext.RouteData.Values["page"]?.ToString()?.EndsWith("ChangePassword") == true ? "active" : string.Empty)" asp-page="./ChangePassword">Parola</a>
+    <a class="nav-link @(ViewContext.RouteData.Values["page"]?.ToString()?.EndsWith("SetPassword") == true ? "active" : string.Empty)" asp-page="./SetPassword">Parola Oluştur</a>
+</nav>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/_StatusMessage.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Manage/_StatusMessage.cshtml
@@ -1,0 +1,5 @@
+@model string
+@if (!string.IsNullOrEmpty(Model))
+{
+    <div class="alert alert-info shadow-sm">@Model</div>
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Register.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,0 +1,71 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.RegisterModel
+@{
+    ViewData["Title"] = "Kayıt Ol";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-7 col-xl-6">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-3">Mülakat yolculuğuna başla</h2>
+                <p class="text-secondary text-center mb-4">
+                    Sorumluluk alanlarını seç, hedef seviyeni belirle ve kişiselleştirilmiş soru akışını aç.
+                </p>
+                <form asp-route-returnUrl="@Model.ReturnUrl" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label asp-for="Input.FullName" class="form-label"></label>
+                            <input asp-for="Input.FullName" class="form-control form-control-lg" autocomplete="name" />
+                            <span asp-validation-for="Input.FullName" class="text-danger"></span>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.CurrentRole" class="form-label"></label>
+                            <input asp-for="Input.CurrentRole" class="form-control form-control-lg" placeholder="Örn. Backend Dev" />
+                            <span asp-validation-for="Input.CurrentRole" class="text-danger"></span>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.TargetLevel" class="form-label"></label>
+                            <select asp-for="Input.TargetLevel" class="form-select form-select-lg">
+                                <option>Junior</option>
+                                <option>Middle</option>
+                                <option>Senior</option>
+                                <option>Lead</option>
+                            </select>
+                            <span asp-validation-for="Input.TargetLevel" class="text-danger"></span>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.Email" class="form-label"></label>
+                            <input asp-for="Input.Email" class="form-control form-control-lg" autocomplete="username" />
+                            <span asp-validation-for="Input.Email" class="text-danger"></span>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.Password" class="form-label"></label>
+                            <input asp-for="Input.Password" class="form-control form-control-lg" autocomplete="new-password" />
+                            <span asp-validation-for="Input.Password" class="text-danger"></span>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+                            <input asp-for="Input.ConfirmPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                            <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100 mt-4">Hesabımı oluştur</button>
+                </form>
+                <div class="mt-4 text-center text-secondary">
+                    Zaten hesabın var mı? <a class="link-light" asp-page="./Login">Giriş yap</a>
+                </div>
+            </div>
+        </div>
+        <div class="card bg-dark bg-opacity-50 border-0 mt-3">
+            <div class="card-body text-secondary text-center small">
+                Kayıt olarak kullanım şartlarımızı ve gizlilik politikamızı kabul etmiş olursun.
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel.DataAnnotations;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class RegisterModel : PageModel
+{
+    private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IUserStore<ApplicationUser> _userStore;
+    private readonly IUserEmailStore<ApplicationUser> _emailStore;
+    private readonly IEmailSender _emailSender;
+
+    public RegisterModel(
+        UserManager<ApplicationUser> userManager,
+        IUserStore<ApplicationUser> userStore,
+        SignInManager<ApplicationUser> signInManager,
+        IEmailSender emailSender)
+    {
+        _userManager = userManager;
+        _userStore = userStore;
+        _emailStore = GetEmailStore();
+        _signInManager = signInManager;
+        _emailSender = emailSender;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public string? ReturnUrl { get; set; }
+
+    public IList<Microsoft.AspNetCore.Authentication.AuthenticationScheme> ExternalLogins { get; set; } = new List<Microsoft.AspNetCore.Authentication.AuthenticationScheme>();
+
+    public class InputModel
+    {
+        [Required(ErrorMessage = "Adınızı ve soyadınızı giriniz.")]
+        [Display(Name = "Ad Soyad")]
+        public string FullName { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Aktif rolünüzü belirtiniz.")]
+        [Display(Name = "Şu anki rolünüz")]
+        public string CurrentRole { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Hedef seviye seçiniz.")]
+        [Display(Name = "Hedef seviye")]
+        public string TargetLevel { get; set; } = "Junior";
+
+        [Required(ErrorMessage = "E-posta adresinizi giriniz.")]
+        [EmailAddress]
+        [Display(Name = "E-posta")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Parola giriniz.")]
+        [StringLength(100, ErrorMessage = "{0} en az {2} en fazla {1} karakter olmalıdır.", MinimumLength = 8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Parola")]
+        public string Password { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Parolayı doğrula")]
+        [Compare("Password", ErrorMessage = "Parolalar eşleşmiyor.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public async Task OnGetAsync(string? returnUrl = null)
+    {
+        ReturnUrl = returnUrl;
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+    }
+
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+    {
+        returnUrl ??= Url.Content("~/");
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+        if (ModelState.IsValid)
+        {
+            var user = CreateUser();
+
+            await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+            await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+            user.FullName = Input.FullName;
+            user.CurrentRole = Input.CurrentRole;
+            user.TargetLevel = Input.TargetLevel;
+
+            var result = await _userManager.CreateAsync(user, Input.Password);
+
+            if (result.Succeeded)
+            {
+                var userId = await _userManager.GetUserIdAsync(user);
+                var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                var callbackUrl = Url.Page(
+                    "/Account/ConfirmEmail",
+                    pageHandler: null,
+                    values: new { area = "Identity", userId, code, returnUrl },
+                    protocol: Request.Scheme);
+
+                await _emailSender.SendEmailAsync(Input.Email, "Turna Interview Studio - E-postanı Doğrula",
+                    $"<p>Merhaba {HtmlEncoder.Default.Encode(Input.FullName)},</p>" +
+                    "<p>Hesabını aktive etmek için aşağıdaki bağlantıya tıkla:</p>" +
+                    $"<p><a href='{HtmlEncoder.Default.Encode(callbackUrl!)}'>Hesabımı doğrula</a></p>");
+
+                if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                {
+                    return RedirectToPage("./RegisterConfirmation", new { email = Input.Email, returnUrl });
+                }
+                else
+                {
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    return LocalRedirect(returnUrl);
+                }
+            }
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+        }
+
+        return Page();
+    }
+
+    private ApplicationUser CreateUser()
+    {
+        try
+        {
+            return Activator.CreateInstance<ApplicationUser>();
+        }
+        catch
+        {
+            throw new InvalidOperationException($"Cannot create an instance of '{nameof(ApplicationUser)}'. " +
+                $"Ensure that '{nameof(ApplicationUser)}' is not an abstract class and has a parameterless constructor, or override the register page in Areas/Identity/Pages/Account/Register.cshtml");
+        }
+    }
+
+    private IUserEmailStore<ApplicationUser> GetEmailStore()
+    {
+        if (!_userManager.SupportsUserEmail)
+        {
+            throw new NotSupportedException("The default UI requires a user store with email support.");
+        }
+        return (IUserEmailStore<ApplicationUser>)_userStore;
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -1,0 +1,25 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.RegisterConfirmationModel
+@{
+    ViewData["Title"] = "Kayıt Onayı";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <div class="feature-icon mx-auto mb-3">
+                    <i class="bi bi-rocket-takeoff fs-4"></i>
+                </div>
+                <h2 class="fw-bold text-white">Hesabın oluşturuldu</h2>
+                <p class="text-secondary">
+                    <strong>@Model.Email</strong> adresine doğrulama bağlantısı gönderdik. Hesabını aktive etmek için e-postanı kontrol et.
+                </p>
+                <p class="text-secondary mb-0">
+                    Bağlantıyı almadıysan spam klasörünü kontrol etmeyi veya birkaç dakika bekleyip tekrar denemeyi unutma.
+                </p>
+                <a class="btn btn-primary mt-4" asp-page="./Login">Giriş ekranına dön</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class RegisterConfirmationModel : PageModel
+{
+    private readonly IEmailSender _emailSender;
+
+    public RegisterConfirmationModel(IEmailSender emailSender)
+    {
+        _emailSender = emailSender;
+    }
+
+    public string Email { get; set; } = string.Empty;
+    public bool DisplayConfirmAccountLink { get; set; }
+    public string EmailConfirmationUrl { get; set; } = string.Empty;
+
+    public async Task<IActionResult> OnGetAsync(string? email, string? returnUrl = null)
+    {
+        if (email == null)
+        {
+            return RedirectToPage("./Register");
+        }
+        Email = email;
+        DisplayConfirmAccountLink = _emailSender == null;
+
+        EmailConfirmationUrl = Url.Page(
+            "/Account/ConfirmEmail",
+            pageHandler: null,
+            values: new { area = "Identity", returnUrl },
+            protocol: Request.Scheme) ?? string.Empty;
+
+        await Task.CompletedTask;
+        return Page();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,42 @@
+@page
+@model InterviewPrep.Web.Areas.Identity.Pages.Account.ResetPasswordModel
+@{
+    ViewData["Title"] = "Parolayı Sıfırla";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xl-5">
+        <div class="auth-card card">
+            <div class="card-body">
+                <h2 class="fw-bold text-white text-center mb-3">Yeni parolanı belirle</h2>
+                <p class="text-secondary text-center mb-4">
+                    Mülakat planlarını aksatmamak için güçlü bir parola oluştur. Büyük/küçük harf ve rakam kullanmayı unutma.
+                </p>
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                    <input asp-for="Input.Code" type="hidden" />
+                    <div class="mb-3">
+                        <label asp-for="Input.Email" class="form-label"></label>
+                        <input asp-for="Input.Email" class="form-control form-control-lg" autocomplete="username" />
+                        <span asp-validation-for="Input.Email" class="text-danger"></span>
+                    </div>
+                    <div class="mb-3">
+                        <label asp-for="Input.Password" class="form-label"></label>
+                        <input asp-for="Input.Password" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.Password" class="text-danger"></span>
+                    </div>
+                    <div class="mb-3">
+                        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+                        <input asp-for="Input.ConfirmPassword" class="form-control form-control-lg" autocomplete="new-password" />
+                        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg w-100">Parolayı Güncelle</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel.DataAnnotations;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+
+namespace InterviewPrep.Web.Areas.Identity.Pages.Account;
+
+public class ResetPasswordModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public ResetPasswordModel(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "E-posta")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, ErrorMessage = "{0} en az {2} en fazla {1} karakter olmalıdır.", MinimumLength = 8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Yeni parola")]
+        public string Password { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Parolayı doğrula")]
+        [Compare("Password", ErrorMessage = "Parolalar eşleşmiyor.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        public string Code { get; set; } = string.Empty;
+    }
+
+    public IActionResult OnGet(string? code = null)
+    {
+        if (code == null)
+        {
+            return BadRequest("Parola sıfırlama kodu gereklidir.");
+        }
+
+        Input = new InputModel
+        {
+            Code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code))
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = await _userManager.FindByEmailAsync(Input.Email);
+        if (user == null)
+        {
+            return RedirectToPage("./ResetPasswordConfirmation");
+        }
+
+        var result = await _userManager.ResetPasswordAsync(user, Input.Code, Input.Password);
+        if (result.Succeeded)
+        {
+            return RedirectToPage("./ResetPasswordConfirmation");
+        }
+
+        foreach (var error in result.Errors)
+        {
+            ModelState.AddModelError(string.Empty, error.Description);
+        }
+        return Page();
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/ResetPasswordConfirmation.cshtml
@@ -1,0 +1,22 @@
+@page
+@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+@{
+    ViewData["Title"] = "Parola Güncellendi";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="auth-card card text-center">
+            <div class="card-body">
+                <div class="feature-icon mx-auto mb-3">
+                    <i class="bi bi-shield-check fs-4"></i>
+                </div>
+                <h2 class="fw-bold text-white">Parolan yenilendi</h2>
+                <p class="text-secondary mt-3">
+                    Yeni parolanla giriş yapabilir ve mülakat seanslarına kaldığın yerden devam edebilirsin.
+                </p>
+                <a class="btn btn-primary mt-3" asp-page="./Login">Giriş yap</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/_ViewImports.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/Account/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using InterviewPrep.Web.Areas.Identity.Pages.Account
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/_ViewImports.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using InterviewPrep.Web
+@using InterviewPrep.Web.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/_ViewStart.cshtml
+++ b/services/turna96/InterviewPrep.Web/Areas/Identity/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "/Views/Shared/_Layout.cshtml";
+}

--- a/services/turna96/InterviewPrep.Web/Controllers/HomeController.cs
+++ b/services/turna96/InterviewPrep.Web/Controllers/HomeController.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterviewPrep.Web.Controllers;
+
+public class HomeController : Controller
+{
+    [AllowAnonymous]
+    public IActionResult Index()
+    {
+        return View();
+    }
+
+    [AllowAnonymous]
+    public IActionResult Privacy()
+    {
+        return View();
+    }
+
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult Error()
+    {
+        return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Data/ApplicationDbContext.cs
+++ b/services/turna96/InterviewPrep.Web/Data/ApplicationDbContext.cs
@@ -1,0 +1,18 @@
+using InterviewPrep.Web.Models;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace InterviewPrep.Web.Data;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+    }
+}

--- a/services/turna96/InterviewPrep.Web/InterviewPrep.Web.csproj
+++ b/services/turna96/InterviewPrep.Web/InterviewPrep.Web.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>InterviewPrep.Web</RootNamespace>
+    <UserSecretsId>aspnet-InterviewPrep-Web-Identity</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
+  </ItemGroup>
+</Project>

--- a/services/turna96/InterviewPrep.Web/Models/ApplicationUser.cs
+++ b/services/turna96/InterviewPrep.Web/Models/ApplicationUser.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace InterviewPrep.Web.Models;
+
+public class ApplicationUser : IdentityUser
+{
+    public string? FullName { get; set; }
+    public string? CurrentRole { get; set; }
+    public string? TargetLevel { get; set; }
+}

--- a/services/turna96/InterviewPrep.Web/Models/ErrorViewModel.cs
+++ b/services/turna96/InterviewPrep.Web/Models/ErrorViewModel.cs
@@ -1,0 +1,8 @@
+namespace InterviewPrep.Web.Models;
+
+public class ErrorViewModel
+{
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+}

--- a/services/turna96/InterviewPrep.Web/Program.cs
+++ b/services/turna96/InterviewPrep.Web/Program.cs
@@ -1,0 +1,61 @@
+using InterviewPrep.Web.Data;
+using InterviewPrep.Web.Models;
+using InterviewPrep.Web.Services.Email;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+builder.Services.AddDefaultIdentity<ApplicationUser>(options =>
+    {
+        options.SignIn.RequireConfirmedAccount = true;
+        options.Password.RequireDigit = true;
+        options.Password.RequireLowercase = true;
+        options.Password.RequireUppercase = true;
+        options.Password.RequireNonAlphanumeric = false;
+        options.Password.RequiredLength = 8;
+        options.Lockout.MaxFailedAccessAttempts = 5;
+        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
+    })
+    .AddRoles<IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>();
+
+builder.Services.AddSingleton<IEmailSender, DebugEmailSender>();
+
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseMigrationsEndPoint();
+}
+else
+{
+    app.UseExceptionHandler("/Home/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}");
+app.MapRazorPages();
+
+app.Run();

--- a/services/turna96/InterviewPrep.Web/Properties/launchSettings.json
+++ b/services/turna96/InterviewPrep.Web/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "InterviewPrep.Web": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7043;http://localhost:5043",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/services/turna96/InterviewPrep.Web/Services/Email/DebugEmailSender.cs
+++ b/services/turna96/InterviewPrep.Web/Services/Email/DebugEmailSender.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Logging;
+
+namespace InterviewPrep.Web.Services.Email;
+
+public class DebugEmailSender : IEmailSender
+{
+    private readonly ILogger<DebugEmailSender> _logger;
+
+    public DebugEmailSender(ILogger<DebugEmailSender> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        _logger.LogInformation("Email captured for debugging. To: {Email}, Subject: {Subject}, BodyLength: {Length}", email, subject, htmlMessage?.Length ?? 0);
+        return Task.CompletedTask;
+    }
+}

--- a/services/turna96/InterviewPrep.Web/Views/Home/Index.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Home/Index.cshtml
@@ -1,0 +1,61 @@
+@{
+    ViewData["Title"] = "Mülakat Stüdyosu";
+}
+
+<section class="row justify-content-center text-center text-lg-start">
+    <div class="col-12 col-lg-10">
+        <div class="card hero-card border-0 overflow-hidden">
+            <div class="card-body p-5 p-lg-6">
+                <div class="row align-items-center g-5">
+                    <div class="col-lg-6">
+                        <span class="badge bg-gradient text-uppercase text-white mb-3">Faz 1 · Kimlik ve Giriş</span>
+                        <h1 class="display-5 fw-bold text-white">Teknik mülakatlara tam donanımlı hazırlan.</h1>
+                        <p class="lead text-light opacity-75 mt-3">
+                            Gerçek şirket senaryoları, görev tabanlı oturumlar ve kişiselleştirilmiş gelişim raporlarıyla
+                            Turna96 Interview Studio seni bir üst seviyeye taşır.
+                        </p>
+                        <div class="d-flex flex-column flex-md-row gap-3 mt-4">
+                            <a class="btn btn-primary btn-lg px-4" asp-area="Identity" asp-page="/Account/Register">Ücretsiz Başla</a>
+                            <a class="btn btn-outline-light btn-lg px-4" asp-area="Identity" asp-page="/Account/Login">Oturum Aç</a>
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                        <div class="row g-4">
+                            <div class="col-12">
+                                <div class="p-4 rounded-4 border border-secondary-subtle h-100 bg-dark bg-opacity-50">
+                                    <div class="d-flex align-items-start gap-3">
+                                        <div class="feature-icon">
+                                            <i class="bi bi-graph-up-arrow fs-4"></i>
+                                        </div>
+                                        <div class="text-start">
+                                            <h5 class="text-white mb-1">Dinamik performans panosu</h5>
+                                            <p class="text-light mb-0 small">Günlük ve haftalık başarı oranlarını gör, hangi konularda gelişmen gerektiğini takip et.</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="p-4 rounded-4 border border-secondary-subtle h-100 bg-dark bg-opacity-50">
+                                    <div class="feature-icon mb-3">
+                                        <i class="bi bi-lightning-charge fs-5"></i>
+                                    </div>
+                                    <h6 class="text-white">Gerçekçi senaryolar</h6>
+                                    <p class="text-light small mb-0">Klasik sorudan sistem tasarımına kadar uçtan uca mülakat simülasyonu.</p>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="p-4 rounded-4 border border-secondary-subtle h-100 bg-dark bg-opacity-50">
+                                    <div class="feature-icon mb-3">
+                                        <i class="bi bi-shield-lock fs-5"></i>
+                                    </div>
+                                    <h6 class="text-white">Kurumsal güvenlik</h6>
+                                    <p class="text-light small mb-0">Çok faktörlü giriş ve güçlü parola politikalarıyla verilerin güvende.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/services/turna96/InterviewPrep.Web/Views/Home/Privacy.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Home/Privacy.cshtml
@@ -1,0 +1,22 @@
+@{
+    ViewData["Title"] = "Gizlilik";
+}
+
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <div class="auth-card card text-light">
+            <div class="card-body">
+                <h2 class="h4 fw-bold mb-4">Gizlilik Politikası</h2>
+                <p class="text-secondary">
+                    Turna96 Interview Studio olarak adayların mülakat performanslarını güvenle takip edebilmeleri için
+                    kimlik doğrulama ve kişisel verilerin korunmasına öncelik veririz. Hesap aktiviteleri şifrelenmiş olarak
+                    saklanır, üçüncü taraflarla paylaşılmaz ve sadece platform deneyimini iyileştirmek amacıyla kullanılır.
+                </p>
+                <p class="text-secondary">
+                    Kimlik verilerinizle ilgili sorularınız için destek ekibimizle iletişime geçebilirsiniz. Hesabınızı
+                    dilediğiniz zaman silebilir, verilerinizi taşıyabilir veya export talebinde bulunabilirsiniz.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Views/Shared/Error.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Shared/Error.cshtml
@@ -1,0 +1,22 @@
+@model ErrorViewModel
+@{
+    ViewData["Title"] = "Hata";
+}
+
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="auth-card card text-light">
+            <div class="card-body text-center">
+                <h1 class="display-6 fw-bold text-danger">Bir sorun oluştu</h1>
+                <p class="text-secondary">İşleminiz sırasında beklenmeyen bir durumla karşılaştık. Lütfen tekrar deneyin.</p>
+                @if (Model?.ShowRequestId == true)
+                {
+                    <div class="text-muted small">İstek Numarası: <code>@Model.RequestId</code></div>
+                }
+                <div class="mt-4">
+                    <a class="btn btn-outline-light" asp-controller="Home" asp-action="Index">Ana sayfaya dön</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/turna96/InterviewPrep.Web/Views/Shared/_Layout.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Shared/_Layout.cshtml
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Turna Interview Studio</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" integrity="sha384-AEfDzQWYslNKxm1LvX7MZccIWt55fXnA8+ZPcpEkhGgix8axW+Xr9RrH1yH3SYF8" crossorigin="anonymous">
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body class="bg-dark text-light">
+    <header>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-gradient shadow-sm">
+            <div class="container">
+                <a class="navbar-brand fw-bold" asp-area="" asp-controller="Home" asp-action="Index">
+                    <span class="text-primary">Turna96</span> Interview Studio
+                </a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                        <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Index">Ana Sayfa</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Privacy">Gizlilik</a></li>
+                    </ul>
+                    <partial name="_LoginPartial" />
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="bg-dark gradient-overlay flex-grow-1">
+        <main role="main" class="pb-4">
+            <div class="container py-5">
+                @RenderBody()
+            </div>
+        </main>
+    </div>
+    <footer class="bg-black text-muted py-4 mt-auto border-top border-secondary">
+        <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center">
+            <div>
+                <strong>Turna96 Interview Studio</strong>
+                <div class="small">Gerçekçi teknik mülakat simülasyonlarıyla kariyerini güçlendir.</div>
+            </div>
+            <div class="small">&copy; @DateTime.Now.Year - Turna96</div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/services/turna96/InterviewPrep.Web/Views/Shared/_LoginPartial.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Shared/_LoginPartial.cshtml
@@ -1,0 +1,31 @@
+@using Microsoft.AspNetCore.Identity
+@using InterviewPrep.Web.Models
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+<ul class="navbar-nav ms-auto align-items-lg-center gap-2">
+@if (SignInManager.IsSignedIn(User))
+{
+    <li class="nav-item text-white small">
+        <span class="badge bg-primary text-uppercase">@((await UserManager.GetUserAsync(User))?.TargetLevel ?? "Aday")</span>
+        <span class="ms-2">@User.Identity?.Name</span>
+    </li>
+    <li class="nav-item">
+        <a class="btn btn-outline-light btn-sm" asp-area="Identity" asp-page="/Account/Manage/Index">Profil</a>
+    </li>
+    <li class="nav-item">
+        <form class="d-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })" method="post">
+            <button type="submit" class="btn btn-danger btn-sm">Çıkış</button>
+        </form>
+    </li>
+}
+else
+{
+    <li class="nav-item">
+        <a class="btn btn-outline-light btn-sm" asp-area="Identity" asp-page="/Account/Login">Giriş</a>
+    </li>
+    <li class="nav-item">
+        <a class="btn btn-primary btn-sm" asp-area="Identity" asp-page="/Account/Register">Kayıt Ol</a>
+    </li>
+}
+</ul>

--- a/services/turna96/InterviewPrep.Web/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,3 @@
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js" integrity="sha384-1pG0qZDRFZx9AHmT9N0CvjfahKc7Ax15om6vuZzi1ev0pEWSrtnqD37dkOb7VU4F" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js" integrity="sha384-xnrcT0DpD6/COM24kTx5cDIeEJD7BqXc9E+u6KDAdAm8YGtS+wGGyRyvE4s46F+a" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation-unobtrusive@4.0.0/dist/jquery.validate.unobtrusive.min.js" integrity="sha384-GESQ9UpAJZciV06P88eaJEqn3Ejj6+UeJ8V+RaH//RUW2KIiMzFxLpy0X58F3RJT" crossorigin="anonymous"></script>

--- a/services/turna96/InterviewPrep.Web/Views/_ViewImports.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using InterviewPrep.Web
+@using InterviewPrep.Web.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/services/turna96/InterviewPrep.Web/Views/_ViewStart.cshtml
+++ b/services/turna96/InterviewPrep.Web/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}

--- a/services/turna96/InterviewPrep.Web/appsettings.Development.json
+++ b/services/turna96/InterviewPrep.Web/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/services/turna96/InterviewPrep.Web/appsettings.json
+++ b/services/turna96/InterviewPrep.Web/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=InterviewPrep;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/services/turna96/InterviewPrep.Web/wwwroot/css/site.css
+++ b/services/turna96/InterviewPrep.Web/wwwroot/css/site.css
@@ -1,0 +1,88 @@
+:root {
+    --primary-gradient: linear-gradient(135deg, #2d2f76, #5e3bc0, #c6426e);
+    --card-bg: rgba(23, 23, 35, 0.8);
+    --border-glow: rgba(94, 59, 192, 0.4);
+}
+
+body {
+    font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Roboto', sans-serif;
+    background: #0e0f1d;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.bg-gradient {
+    background: var(--primary-gradient);
+}
+
+.gradient-overlay {
+    background: radial-gradient(circle at top left, rgba(94, 59, 192, 0.25), transparent 40%),
+        radial-gradient(circle at bottom right, rgba(198, 66, 110, 0.25), transparent 45%);
+}
+
+.hero-card {
+    background: var(--card-bg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1.5rem;
+    backdrop-filter: blur(18px);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+.hero-card .card-header {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.feature-icon {
+    width: 3rem;
+    height: 3rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.75rem;
+    background: rgba(94, 59, 192, 0.25);
+    color: #f8f9ff;
+}
+
+.auth-card {
+    background: rgba(20, 20, 32, 0.92);
+    border-radius: 1.25rem;
+    border: 1px solid var(--border-glow);
+    box-shadow: 0 18px 48px rgba(20, 18, 55, 0.6);
+}
+
+.auth-card .card-body {
+    padding: 2.5rem;
+}
+
+.auth-card label {
+    font-weight: 600;
+}
+
+.auth-card .form-control {
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+}
+
+.auth-card .form-control:focus {
+    border-color: #5e3bc0;
+    box-shadow: 0 0 0 0.25rem rgba(94, 59, 192, 0.25);
+}
+
+.auth-card .form-text {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.link-light-muted {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.link-light-muted:hover {
+    color: #fff;
+}
+
+.table-progress th,
+.table-progress td {
+    vertical-align: middle;
+}

--- a/services/turna96/InterviewPrep.Web/wwwroot/js/site.js
+++ b/services/turna96/InterviewPrep.Web/wwwroot/js/site.js
@@ -1,0 +1,15 @@
+(() => {
+    const streakElement = document.querySelector('[data-streak-progress]');
+    if (!streakElement) {
+        return;
+    }
+
+    const streak = Number.parseInt(streakElement.dataset.streakProgress ?? '0', 10);
+    const target = streakElement.querySelector('.progress-bar');
+    if (!target) {
+        return;
+    }
+
+    const normalized = Math.min(100, streak);
+    target.style.width = `${normalized}%`;
+})();

--- a/services/turna96/InterviewPrep.sln
+++ b/services/turna96/InterviewPrep.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterviewPrep.Web", "InterviewPrep.Web/InterviewPrep.Web.csproj", "{38EAB430-983A-4C71-91D5-356D868CF383}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {38EAB430-983A-4C71-91D5-356D868CF383}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {38EAB430-983A-4C71-91D5-356D868CF383}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {38EAB430-983A-4C71-91D5-356D868CF383}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {38EAB430-983A-4C71-91D5-356D868CF383}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- introduce InterviewPrep ASP.NET Core MVC solution with Identity-backed ApplicationDbContext and extended ApplicationUser profile fields
- design dark themed Bootstrap 5 views for login, registration, password recovery, 2FA, and account management tailored to the interview simulation experience
- add phase 1 identity rollout report with setup instructions and next steps

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce3aa450b08332ba338a041abcafaf